### PR TITLE
Replaced ExpectedApproxDuration with generic ExpectedApprox

### DIFF
--- a/assert/assert.go
+++ b/assert/assert.go
@@ -48,7 +48,7 @@ func ExpectedApproxTime(t Tester, expected, actual time.Time, epsilon time.Durat
 // ExpectedApprox logs a testing error and returns false if the expected and actual values are not close.
 // Specifically, if the absolute value of the difference between the two is LARGER than the given "epsilon".
 // Typically you will not need the return value unless you want to stop testing on failure.
-func ExpectedApprox[V num.Integer | num.Float](t Tester, expected, actual, epsilon V, name string) bool {
+func ExpectedApprox[V num.Real](t Tester, expected, actual, epsilon V, name string) bool {
 	delta := getDelta(actual, expected)
 	if delta > epsilon {
 		t.Helper() // Marks this func as a Helper, so this error gets logged at the caller's location
@@ -60,7 +60,7 @@ func ExpectedApprox[V num.Integer | num.Float](t Tester, expected, actual, epsil
 
 // This exists because subtractions for unsigned numbers cannot possibly go negative, so I want to just
 // avoid doing the subtraction. Since this is for testing, relative performance for this isn't a big concern.
-func getDelta[V num.Integer | num.Float](a, b V) V {
+func getDelta[V num.Real](a, b V) V {
 	if a > b {
 		return a - b
 	}

--- a/gmath/math.go
+++ b/gmath/math.go
@@ -15,7 +15,8 @@ func Clamp[N num.Real](val, min, max N) N {
 
 // Lerp linearly interpolates between a and b using t. t is clamped between 0.0 and 1.0.
 // eg, when t is 0.0, this returns a. When t is 1.0 this returns b. When t is 0.5 this returns the midpoint between a and b.
-// NOTE: Lerping unsigned values is not recommended - there may be unexpected results when a > b. Suggest casting to a float prior to this.
+// NOTE: Lerping unsigned values is not recommended - there may be unexpected results when a > b.
+// Suggest ordering such that a <= b, or casting to a float prior to calling this function.
 func Lerp[N num.Real, F num.Float](a, b N, t F) N {
 	// If you're using floats, there's effectively no cost to the casting done here with F(b-a).
 	// If you're not, you'd have to cast at some point anyway or otherwise do something clever to get a useful interpolation.

--- a/gmath/math.go
+++ b/gmath/math.go
@@ -15,8 +15,8 @@ func Clamp[N num.Real](val, min, max N) N {
 
 // Lerp linearly interpolates between a and b using t. t is clamped between 0.0 and 1.0.
 // eg, when t is 0.0, this returns a. When t is 1.0 this returns b. When t is 0.5 this returns the midpoint between a and b.
-// NOTE: Lerping unsigned values is not recommended - there may be unexpected results when a > b.
-// Suggest ordering such that a <= b, or casting to a float prior to calling this function.
+// NOTE: Lerping unsigned values requires extra care - there may be unexpected results when a > b.
+// Suggest ordering [a, b] such that a <= b, or casting to a float prior to calling this function.
 func Lerp[N num.Real, F num.Float](a, b N, t F) N {
 	// If you're using floats, there's effectively no cost to the casting done here with F(b-a).
 	// If you're not, you'd have to cast at some point anyway or otherwise do something clever to get a useful interpolation.

--- a/gmath/math.go
+++ b/gmath/math.go
@@ -3,13 +3,8 @@ package gmath
 
 import "github.com/seanpfeifer/rigging/num"
 
-// BasicNumbers is everything that's not a complex number (excludes complex64, complex128)
-type BasicNumbers interface {
-	num.Integer | num.Float
-}
-
 // Clamp will return the value clamped between min and max, inclusive.
-func Clamp[N BasicNumbers](val, min, max N) N {
+func Clamp[N num.Real](val, min, max N) N {
 	if val < min {
 		return min
 	} else if val > max {
@@ -20,7 +15,7 @@ func Clamp[N BasicNumbers](val, min, max N) N {
 
 // Lerp linearly interpolates between a and b using t. t is clamped between 0.0 and 1.0.
 // eg, when t is 0.0, this returns a. When t is 1.0 this returns b. When t is 0.5 this returns the midpoint between a and b.
-func Lerp[N BasicNumbers, F num.Float](a, b N, t F) N {
+func Lerp[N num.Real, F num.Float](a, b N, t F) N {
 	// If you're using floats, there's effectively no cost to the casting done here with F(b-a).
 	// If you're not, you'd have to cast at some point anyway or otherwise do something clever to get a useful interpolation.
 	return a + N(F(b-a)*Clamp(t, 0, 1))

--- a/gmath/math.go
+++ b/gmath/math.go
@@ -1,9 +1,11 @@
 // Package gmath includes useful math funcs for games, graphics, and GUIs.
 package gmath
 
+import "github.com/seanpfeifer/rigging/num"
+
 // BasicNumbers is everything that's not a complex number (excludes complex64, complex128)
 type BasicNumbers interface {
-	Integer | Float
+	num.Integer | num.Float
 }
 
 // Clamp will return the value clamped between min and max, inclusive.
@@ -18,7 +20,7 @@ func Clamp[N BasicNumbers](val, min, max N) N {
 
 // Lerp linearly interpolates between a and b using t. t is clamped between 0.0 and 1.0.
 // eg, when t is 0.0, this returns a. When t is 1.0 this returns b. When t is 0.5 this returns the midpoint between a and b.
-func Lerp[N BasicNumbers, F Float](a, b N, t F) N {
+func Lerp[N BasicNumbers, F num.Float](a, b N, t F) N {
 	// If you're using floats, there's effectively no cost to the casting done here with F(b-a).
 	// If you're not, you'd have to cast at some point anyway or otherwise do something clever to get a useful interpolation.
 	return a + N(F(b-a)*Clamp(t, 0, 1))

--- a/gmath/math.go
+++ b/gmath/math.go
@@ -15,6 +15,7 @@ func Clamp[N num.Real](val, min, max N) N {
 
 // Lerp linearly interpolates between a and b using t. t is clamped between 0.0 and 1.0.
 // eg, when t is 0.0, this returns a. When t is 1.0 this returns b. When t is 0.5 this returns the midpoint between a and b.
+// NOTE: Lerping unsigned values is not recommended - there may be unexpected results when a > b. Suggest casting to a float prior to this.
 func Lerp[N num.Real, F num.Float](a, b N, t F) N {
 	// If you're using floats, there's effectively no cost to the casting done here with F(b-a).
 	// If you're not, you'd have to cast at some point anyway or otherwise do something clever to get a useful interpolation.

--- a/gmath/math_test.go
+++ b/gmath/math_test.go
@@ -25,7 +25,7 @@ func TestLerp(t *testing.T) {
 	// Unsigned is generally a bad idea. Cast to a float instead.
 	ExpectedActual(t, 100, Lerp(uint8(0), 100, 1.0), "uint8 max")
 	ExpectedActual(t, 20, Lerp(uint8(100), 20, 1.0), "uint8 reverse max")
-	// This is a problem when a > b. Instead, cast these to a float!
+	// This is a problem when a > b. Instead, reorder them (ideal) or cast these to a float!
 	// FAIL: ExpectedActual(t, 75, Lerp(uint8(100), 0, 0.25), "uint8 reverse 25%") -> ACTUAL: 139
 	ExpectedActual(t, 75, Lerp(float64(uint8(100)), 0, 0.25), "uint8 reverse 25%")
 }

--- a/gmath/math_test.go
+++ b/gmath/math_test.go
@@ -13,6 +13,23 @@ func TestClamp(t *testing.T) {
 	ExpectedActual(t, 1.0, Clamp(2.0, 0.0, 1.0), "clamp to max (float)")
 }
 
+func TestLerp(t *testing.T) {
+	ExpectedActual(t, 25, Lerp(int64(0), 100, 0.25), "int64 25%")
+	ExpectedActual(t, 20, Lerp(int64(20), 100, 0.0), "int64 min")
+	ExpectedActual(t, 100, Lerp(int64(20), 100, 1.0), "int64 max")
+
+	ExpectedActual(t, 75, Lerp(int64(100), 0, 0.25), "int64 reverse 25%")
+	ExpectedActual(t, 100, Lerp(int64(100), 20, 0.0), "int64 reverse min")
+	ExpectedActual(t, 20, Lerp(int64(100), 20, 1.0), "int64 reverse max")
+
+	// Unsigned is generally a bad idea. Cast to a float instead.
+	ExpectedActual(t, 100, Lerp(uint8(0), 100, 1.0), "uint8 max")
+	ExpectedActual(t, 20, Lerp(uint8(100), 20, 1.0), "uint8 reverse max")
+	// This is a problem when a > b. Instead, cast these to a float!
+	// FAIL: ExpectedActual(t, 75, Lerp(uint8(100), 0, 0.25), "uint8 reverse 25%") -> ACTUAL: 139
+	ExpectedActual(t, 75, Lerp(float64(uint8(100)), 0, 0.25), "uint8 reverse 25%")
+}
+
 // Note: You can run these benchmarks with a command like:
 //    go test -benchtime=20000000000x -benchmem -bench .
 

--- a/num/constraints.go
+++ b/num/constraints.go
@@ -19,3 +19,8 @@ type Unsigned interface {
 type Integer interface {
 	Signed | Unsigned
 }
+
+// Real is everything that's not a complex number (excludes complex64, complex128)
+type Real interface {
+	Integer | Float
+}

--- a/num/constraints.go
+++ b/num/constraints.go
@@ -1,4 +1,4 @@
-package gmath
+package num
 
 // Float is a constraint for floating-point types.
 type Float interface {


### PR DESCRIPTION
This is a breaking change, and users must migrate from `ExpectedApproxDuration` to use new versions.

Also:
* Moved useful constraints to new `num` package, eg `num.Integer`, `num.Real`
* Added tests for `gmath.Lerp`