### PR TITLE
Go 1.24 crypto update + API simplification

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/seanpfeifer/rigging
 
-go 1.21
+go 1.24
 
 require (
 	github.com/BurntSushi/toml v1.4.0
-	golang.org/x/crypto v0.32.0
+	golang.org/x/crypto v0.33.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
-golang.org/x/crypto v0.32.0 h1:euUpcYgM8WcP71gNpTqQCn6rC2t6ULUPiOzfWaXVVfc=
-golang.org/x/crypto v0.32.0/go.mod h1:ZnnJkOaASj8g0AjIduWNlq2NRxL0PlBrbKVyZ6V/Ugc=
+golang.org/x/crypto v0.33.0 h1:IOBPskki6Lysi0lo9qQvbxiQ+FvsCC/YWOecCHAixus=
+golang.org/x/crypto v0.33.0/go.mod h1:bVdXmD7IV/4GdElGPozy6U7lWdRXA4qyRVGJV57uQ5M=

--- a/hashing/hmac.go
+++ b/hashing/hmac.go
@@ -38,13 +38,13 @@ func (key *HMACKey) IsValid(msg string, givenMac []byte) bool {
 
 // NewHMACKey creates a new cryptographically random HMAC key with HMACKeySize bytes.
 //
-// You typically will want to store the output of this and use it repeatedly, hashing messages that you send out
+// You typically will want to store the output of this (the generated key) and use it repeatedly, hashing messages that you send out
 // and checking validity when returned to you.
-func NewHMACKey() (HMACKey, error) {
+func NewHMACKey() HMACKey {
 	var key HMACKey
-	if _, err := rand.Read(key[:]); err != nil {
-		return key, err
-	}
+	//  This cannot error, and will crash the program irrecoverably if an error is returned, per Go 1.24 crypto/rand.Read().
+	// crypto/rand.Read() will ALWAYS fill the buffer and not return an error, so I'm intentionally ignoring both return values here
+	_, _ = rand.Read(key[:])
 
-	return key, nil
+	return key
 }

--- a/hashing/hmac_test.go
+++ b/hashing/hmac_test.go
@@ -12,10 +12,7 @@ const (
 )
 
 func TestIsValid(t *testing.T) {
-	key, err := NewHMACKey()
-	if err != nil {
-		t.FailNow()
-	}
+	key := NewHMACKey()
 
 	// Reset the timer, since we don't want to time the setup we had to do
 	hash := key.Hash(dataToBeHashed)
@@ -29,10 +26,7 @@ func TestIsValid(t *testing.T) {
 }
 
 func BenchmarkHashHMAC(b *testing.B) {
-	key, err := NewHMACKey()
-	if err != nil {
-		b.FailNow()
-	}
+	key := NewHMACKey()
 
 	// Reset the timer, since we don't want to time the setup we had to do
 	b.ResetTimer()
@@ -42,10 +36,7 @@ func BenchmarkHashHMAC(b *testing.B) {
 }
 
 func BenchmarkVerifyHMAC(b *testing.B) {
-	key, err := NewHMACKey()
-	if err != nil {
-		b.FailNow()
-	}
+	key := NewHMACKey()
 	hash := key.Hash(dataToBeHashed)
 
 	// Reset the timer, since we don't want to time the setup we had to do

--- a/uuid/random.go
+++ b/uuid/random.go
@@ -3,7 +3,6 @@ package uuid
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"io"
 )
 
 // RandomID is a random 16 byte ID. This is similar to a random UUID (RFC 4122), except it lacks the formatting and is
@@ -12,12 +11,15 @@ import (
 // If you want something that abides by RFC 4122, use https://github.com/google/uuid
 type RandomID [16]byte
 
-// NewRandom returns a new random ID, or an error if we fail to read from crypto/rand.
-func NewRandom() (RandomID, error) {
+// NewRandom returns a new random ID.
+// It can never error, and crashes the program irrecoverably if an error is returned, per Go 1.24 crypto/rand.Read().
+// This crash will only happen on legacy Linux systems (prior to verison 3.17). See https://github.com/golang/go/issues/66821
+func NewRandom() RandomID {
 	var id RandomID
-	_, err := io.ReadFull(rand.Reader, id[:])
+	// crypto/rand.Read() will ALWAYS fill the buffer and not return an error, so I'm intentionally ignoring both return values here
+	_, _ = rand.Read(id[:])
 
-	return id, err
+	return id
 }
 
 // String returns the RandomID as a 32-character hex string, with no separators.

--- a/uuid/random_test.go
+++ b/uuid/random_test.go
@@ -7,8 +7,7 @@ import (
 )
 
 func TestRandom(t *testing.T) {
-	id, err := NewRandom()
-	ExpectedActual(t, nil, err, "new random")
+	id := NewRandom()
 	str := id.String()
 	ExpectedActual(t, 32, len(str), "hex string length")
 }


### PR DESCRIPTION
This is a breaking change to these two APIs to simplify usage by removing unnecessary error checking.