### PR TITLE
Modernize benchmarks

### DIFF
--- a/gmath/math.go
+++ b/gmath/math.go
@@ -4,13 +4,13 @@ package gmath
 import "github.com/seanpfeifer/rigging/num"
 
 // Clamp will return the value clamped between min and max, inclusive.
-func Clamp[N num.Real](val, min, max N) N {
-	// This is significantly faster (~85% as of Go 1.26.0) than `min(max(val, minVal), maxVal)`, so we're going to
+func Clamp[N num.Real](val, minVal, maxVal N) N {
+	// This is significantly faster (~56% as of Go 1.26.0) than `min(max(val, minVal), maxVal)`, so we're going to
 	// keep providing this function and use this implementation of it.
-	if val < min {
-		return min
-	} else if val > max {
-		return max
+	if val < minVal {
+		return minVal
+	} else if val > maxVal {
+		return maxVal
 	}
 	return val
 }

--- a/gmath/math_test.go
+++ b/gmath/math_test.go
@@ -37,7 +37,7 @@ var resultF64 float64
 
 func BenchmarkLerpFloat64(b *testing.B) {
 	var res float64
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		res = Lerp(0.0, 1.0, 0.5)
 	}
 	resultF64 = res
@@ -47,7 +47,7 @@ var resultF32 float32
 
 func BenchmarkLerpFloat32(b *testing.B) {
 	var res float32
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		// Explicitly using float32 here as a convenience so we don't have to cast the params.
 		// In a real-world case you'd just pass your float32 vars / constants.
 		res = Lerp[float32](0.0, 1.0, 0.5)
@@ -59,7 +59,7 @@ var resultI64 int64
 
 func BenchmarkLerpInt64(b *testing.B) {
 	var res int64
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		res = Lerp[int64](0, 100, 0.5)
 	}
 	resultI64 = res
@@ -69,7 +69,7 @@ var resultI32 int32
 
 func BenchmarkLerpInt32(b *testing.B) {
 	var res int32
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		res = Lerp[int32](0, 100, 0.5)
 	}
 	resultI32 = res

--- a/hashing/hmac_test.go
+++ b/hashing/hmac_test.go
@@ -28,9 +28,7 @@ func TestIsValid(t *testing.T) {
 func BenchmarkHashHMAC(b *testing.B) {
 	key := NewHMACKey()
 
-	// Reset the timer, since we don't want to time the setup we had to do
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		key.Hash(dataToBeHashed)
 	}
 }
@@ -39,9 +37,7 @@ func BenchmarkVerifyHMAC(b *testing.B) {
 	key := NewHMACKey()
 	hash := key.Hash(dataToBeHashed)
 
-	// Reset the timer, since we don't want to time the setup we had to do
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		key.IsValid(dataToBeHashed, hash)
 	}
 }


### PR DESCRIPTION
No functional changes to packages.

Uses the more accurate and less error-prone `b.Loop()` style for benchmarks.